### PR TITLE
remove limit for getting rewards

### DIFF
--- a/internal/tzkt/rewards.go
+++ b/internal/tzkt/rewards.go
@@ -123,7 +123,7 @@ GetRewardsSplit -
 See: https://api.tzkt.io/#operation/Rewards_GetRewardSplit
 */
 func (t *Tzkt) GetRewardsSplit(delegate string, cycle int, options ...URLParameters) (RewardsSplit, error) {
-	resp, err := t.get(fmt.Sprintf("/v1/rewards/split/%s/%d", delegate, cycle), options...)
+	resp, err := t.get(fmt.Sprintf("/v1/rewards/split/%s/%d?limit=1000", delegate, cycle), options...)
 	if err != nil {
 		return RewardsSplit{}, errors.Wrapf(err, "failed to get reward split")
 	}


### PR DESCRIPTION
Current API the system is using to get rewards - https://api.tzkt.io/#operation/Rewards_GetRewardSplit
As shown in the document, the default limit is 100, which means it returns maximum 100 delegators. 

If the baker has got more than 100 delegators, it won't be able to get full list of delegators. 

Please leave a comment if you see any mistake here.