### PR TITLE
fix payment

### DIFF
--- a/internal/tzkt/rewards.go
+++ b/internal/tzkt/rewards.go
@@ -123,7 +123,7 @@ GetRewardsSplit -
 See: https://api.tzkt.io/#operation/Rewards_GetRewardSplit
 */
 func (t *Tzkt) GetRewardsSplit(delegate string, cycle int, options ...URLParameters) (RewardsSplit, error) {
-	resp, err := t.get(fmt.Sprintf("/v1/rewards/split/%s/%d", delegate, cycle), options...)
+	resp, err := t.get(fmt.Sprintf("/v1/rewards/split/%s/%d?limit=1000", delegate, cycle), options...)
 	if err != nil {
 		return RewardsSplit{}, errors.Wrapf(err, "failed to get reward split")
 	}


### PR DESCRIPTION
Fix payment issues.
As written in the document, the default limit for API request is 100. Which means it is not going to return a full list of delegators in case the baker has got more than 100 delegators. 

Lemme know if you find any mistake.